### PR TITLE
Ensure lockfiles are dumped with a final newline

### DIFF
--- a/news/2.bugfix.rst
+++ b/news/2.bugfix.rst
@@ -1,0 +1,1 @@
+Fix `Lockfile.dump()` to work correctly on Python 2 when outputting to `io`.

--- a/news/2.feature.rst
+++ b/news/2.feature.rst
@@ -1,0 +1,1 @@
+Lock file dumps are now guarenteed to end with a trailing newline.

--- a/src/plette/lockfiles.py
+++ b/src/plette/lockfiles.py
@@ -24,7 +24,15 @@ class _LockFileEncoder(json.JSONEncoder):
         content = super(_LockFileEncoder, self).encode(obj)
         if not isinstance(content, six.text_type):
             content = content.decode("utf-8")
+        content += "\n"
         return content
+
+    def iterencode(self, obj):
+        for chunk in super(_LockFileEncoder, self).iterencode(obj):
+            if not isinstance(chunk, six.text_type):
+                chunk = chunk.decode("utf-8")
+            yield chunk
+        yield "\n"
 
 
 LOCKFILE_SECTIONS = {


### PR DESCRIPTION
Also correctly implement iterencode to work on Python 2.