### PR TITLE
Add Python 3.11 release candidate 2 to the testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10", 3.11-dev]
         os: [ubuntu-latest]
 
     steps:


### PR DESCRIPTION
Python 3.11 will be on average 22% faster than Python 3.10 so let’s give it a spin...
https://www.python.org/download/pre-releases
