### PR TITLE
Exclude pipenv from Pipfile hash generation.

### DIFF
--- a/news/29.bugfix.rst
+++ b/news/29.bugfix.rst
@@ -1,0 +1,1 @@
+Exclude ``pipenv`` section from ``Pipfile`` hash generation as this was a regression caused by named package categories.

--- a/src/plette/pipfiles.py
+++ b/src/plette/pipfiles.py
@@ -81,7 +81,7 @@ class Pipfile(DataView):
             "develop": self._data.get("dev-packages", {}),
         }
         for category, values in self._data.items():
-            if category in PIPFILE_SECTIONS or category in ("default", "develop"):
+            if category in PIPFILE_SECTIONS or category in ("default", "develop", "pipenv"):
                 continue
             data[category] = values
         content = json.dumps(data, sort_keys=True, separators=(",", ":"))


### PR DESCRIPTION
Fixes #29 