### PR TITLE
Update validation schema for Requires

### DIFF
--- a/news/5395.bugfix.rst
+++ b/news/5395.bugfix.rst
@@ -1,0 +1,1 @@
+Change validation schema for Requires object to allow for both ``python_version`` and ``python_full_version``.

--- a/news/5395.bugfix.rst
+++ b/news/5395.bugfix.rst
@@ -1,0 +1,1 @@
+Change validation schema for Requires object to allow for both ``python_version`` and ``python_full_version``. Also added regex validation so that it must be a valid python version and python_version is like 3.10, and python_full_version is like 30.10.7

--- a/news/5395.bugfix.rst
+++ b/news/5395.bugfix.rst
@@ -1,1 +1,0 @@
-Change validation schema for Requires object to allow for both ``python_version`` and ``python_full_version``. Also added regex validation so that it must be a valid python version and python_version is like 3.10, and python_full_version is like 30.10.7

--- a/src/plette/models/sections.py
+++ b/src/plette/models/sections.py
@@ -18,16 +18,14 @@ class SourceCollection(DataViewSequence):
 
 
 class Requires(DataView):
-    """Representation of the `[requires]` section in a Pipfile.
-    """
+    """Representation of the `[requires]` section in a Pipfile."""
+
     __SCHEMA__ = {
         "python_version": {
             "type": "string",
-            "excludes": ["python_full_version"],
         },
         "python_full_version": {
             "type": "string",
-            "excludes": ["python_version"],
         },
     }
 
@@ -54,8 +52,8 @@ META_SECTIONS = {
 
 
 class Meta(DataView):
-    """Representation of the `_meta` section in a Pipfile.lock.
-    """
+    """Representation of the `_meta` section in a Pipfile.lock."""
+
     __SCHEMA__ = {
         "hash": {"type": "dict", "required": True},
         "pipfile-spec": {"type": "integer", "required": True, "min": 0},

--- a/src/plette/models/sections.py
+++ b/src/plette/models/sections.py
@@ -23,11 +23,13 @@ class Requires(DataView):
     __SCHEMA__ = {
         "python_version": {
             "type": "string",
-            "excludes": ["python_full_version"],
+            # matches 3.10 and 2.7 and 4.1
+            "regex": r"[2-4]\.[0-9]{1,2}",
         },
         "python_full_version": {
             "type": "string",
-            "excludes": ["python_version"],
+            # matches 3.10.10 and 2.7.1p1 and 4.1.9 
+            "regex": r"[2-4]\.[0-9]{1,2}\.[0-9p]{1,3}",
         },
     }
 

--- a/src/plette/models/sections.py
+++ b/src/plette/models/sections.py
@@ -23,13 +23,11 @@ class Requires(DataView):
     __SCHEMA__ = {
         "python_version": {
             "type": "string",
-            # matches 3.10 and 2.7 and 4.1
-            "regex": r"[2-4]\.[0-9]{1,2}",
+            "excludes": ["python_full_version"],
         },
         "python_full_version": {
             "type": "string",
-            # matches 3.10.10 and 2.7.1p1 and 4.1.9 
-            "regex": r"[2-4]\.[0-9]{1,2}\.[0-9p]{1,3}",
+            "excludes": ["python_version"],
         },
     }
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -60,36 +60,33 @@ def test_source_as_data_expanded_partial(monkeypatch):
 
 
 def test_requires_python_version():
-    r = models.Requires({"python_version": "8.19"})
-    assert r.python_version == "8.19"
+    r = models.Requires({"python_version": "3.19"})
+    assert r.python_version == "3.19"
 
 
 def test_requires_python_version_no_full_version():
-    r = models.Requires({"python_version": "8.19"})
+    r = models.Requires({"python_version": "3.19"})
     with pytest.raises(AttributeError) as ctx:
         r.python_full_version
     assert str(ctx.value) == "python_full_version"
 
 
-def test_requires_python_full_version():
-    r = models.Requires({"python_full_version": "8.19"})
-    assert r.python_full_version == "8.19"
+def test_requires_python_full_version_match_regex():
+    r = models.Requires({"python_full_version": "3.19.1"})
+    assert r.python_full_version == "3.19.1"
 
 
-def test_requires_python_full_version_no_version():
-    r = models.Requires({"python_full_version": "8.19"})
-    with pytest.raises(AttributeError) as ctx:
-        r.python_version
-    assert str(ctx.value) == "python_version"
+def test_requires_python_fake_version():
+    with pytest.raises(models.base.ValidationError) as ctx:
+        models.Requires({"python_version": "8.19"})
+    assert str(ctx.value) == "{'python_version': '8.19'}\npython_version: value does not match regex '[2-4]\.[0-9]{1,2}'"
 
 
 @pytest.mark.skipif(cerberus is None, reason="Skip validation without Ceberus")
-def test_requires_no_duplicate_python_version():
-    data = {"python_version": "8.19", "python_full_version": "8.1.9"}
-    with pytest.raises(ValueError) as ctx:
-        models.Requires(data)
-    assert cerberus.errors.EXCLUDES_FIELD in ctx.value.validator._errors
-    assert len(ctx.value.validator._errors) == 2
+def test_allows_python_version_and_full():
+    r = models.Requires({"python_version": "3.1", "python_full_version": "3.1.9"})
+    assert r.python_full_version == "3.1.9"
+    assert r.python_version == "3.1"
 
 
 def test_package_str():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -60,33 +60,36 @@ def test_source_as_data_expanded_partial(monkeypatch):
 
 
 def test_requires_python_version():
-    r = models.Requires({"python_version": "3.19"})
-    assert r.python_version == "3.19"
+    r = models.Requires({"python_version": "8.19"})
+    assert r.python_version == "8.19"
 
 
 def test_requires_python_version_no_full_version():
-    r = models.Requires({"python_version": "3.19"})
+    r = models.Requires({"python_version": "8.19"})
     with pytest.raises(AttributeError) as ctx:
         r.python_full_version
     assert str(ctx.value) == "python_full_version"
 
 
-def test_requires_python_full_version_match_regex():
-    r = models.Requires({"python_full_version": "3.19.1"})
-    assert r.python_full_version == "3.19.1"
+def test_requires_python_full_version():
+    r = models.Requires({"python_full_version": "8.19"})
+    assert r.python_full_version == "8.19"
 
 
-def test_requires_python_fake_version():
-    with pytest.raises(models.base.ValidationError) as ctx:
-        models.Requires({"python_version": "8.19"})
-    assert str(ctx.value) == "{'python_version': '8.19'}\npython_version: value does not match regex '[2-4]\.[0-9]{1,2}'"
+def test_requires_python_full_version_no_version():
+    r = models.Requires({"python_full_version": "8.19"})
+    with pytest.raises(AttributeError) as ctx:
+        r.python_version
+    assert str(ctx.value) == "python_version"
 
 
 @pytest.mark.skipif(cerberus is None, reason="Skip validation without Ceberus")
-def test_allows_python_version_and_full():
-    r = models.Requires({"python_version": "3.1", "python_full_version": "3.1.9"})
-    assert r.python_full_version == "3.1.9"
-    assert r.python_version == "3.1"
+def test_requires_no_duplicate_python_version():
+    data = {"python_version": "8.19", "python_full_version": "8.1.9"}
+    with pytest.raises(ValueError) as ctx:
+        models.Requires(data)
+    assert cerberus.errors.EXCLUDES_FIELD in ctx.value.validator._errors
+    assert len(ctx.value.validator._errors) == 2
 
 
 def test_package_str():


### PR DESCRIPTION
Per this bug: https://github.com/pypa/pipenv/issues/5395

Maybe I went a little overboard by adding the regex validations.

Basically made it so both `python_full_version` or `python_version` can be initialized with the `Requires()` object.

Since the main thing "oneof" checks is the validation schemas itself, and the main thing we are checking is the name of the key, i.e.  `python_full_version` or `python_version` i didn't see how to plug in "oneof".