### PR TITLE
bump setuptools version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=36.6.2", "wheel>=0.28.0"]
+requires = ["setuptools>=61.0.0", "wheel>=0.28.0"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/setup.py
+++ b/setup.py
@@ -19,13 +19,11 @@ if VERSION is None:
     raise EnvironmentError('failed to read version')
 
 
-# Put everything in setup.cfg, except those that don't actually work?
 setup(
     # These really don't work.
     package_dir={'': 'src'},
     packages=find_packages('src'),
 
-    # I don't know how to specify an empty key in setup.cfg.
     package_data={
         '': ['LICENSE*', 'README*'],
     },


### PR DESCRIPTION
Fixes #32. `setuptools` is also in Pipfile.lock, but at a very new version.

Now:
```
❯ pip list
Package    Version
---------- -------
pip        21.2.4
setuptools 61.0.0
wheel      0.28.0
❯ python setup.py sdist bdist_wheel
running sdist
...
❯ ls dist/
total 88
-rw-r--r--  1 jeremyp  staff    31K Oct 25 13:09 plette-0.4.2-py2.py3-none-any.whl
-rw-r--r--  1 jeremyp  staff    10K Oct 25 13:09 plette-0.4.2.tar.gz
```