### PR TITLE
Add validation for extras in package specifiers

### DIFF
--- a/examples/Pipfile.invalid.extras-list
+++ b/examples/Pipfile.invalid.extras-list
@@ -1,0 +1,4 @@
+# package specifiers should be a dict
+[packages]
+msal = {version= "==1.20.0", extras = "broker"}
+

--- a/examples/Pipfile.invalid.list
+++ b/examples/Pipfile.invalid.list
@@ -1,0 +1,4 @@
+# package specifiers should be a dict
+[packages]
+msal = ["1.20.0", "broker"]
+

--- a/examples/Pipfile.invalid.with-categories
+++ b/examples/Pipfile.invalid.with-categories
@@ -2,4 +2,4 @@
 plette = { path = '.', extras = ['validation'], editable = true }
 
 [documentation]
-sphinx = "*"
+msal = {version= "==1.20.0", extras = "broker"}

--- a/examples/Pipfile.valid.editable
+++ b/examples/Pipfile.valid.editable
@@ -1,0 +1,3 @@
+[packages]
+parver = '*'
+foo = {path = ".", editable = true, extras = ["tests", "dev"]}

--- a/examples/Pipfile.valid.extras-list
+++ b/examples/Pipfile.valid.extras-list
@@ -1,0 +1,4 @@
+# package extras are a list
+[packages]
+msal = {version= "==1.20.0", extras = ["broker"]}
+

--- a/examples/Pipfile.valid.list
+++ b/examples/Pipfile.valid.list
@@ -1,0 +1,6 @@
+
+# extras should be a list
+[packages]
+msal = {version="==1.20.0", extras=["broker"]}
+parver = '*'
+

--- a/examples/Pipfile.valid.pipfile-section
+++ b/examples/Pipfile.valid.pipfile-section
@@ -1,0 +1,8 @@
+[pipenv]
+install_search_all_sources = true
+
+# extras should be a list
+[packages]
+msal = {version="==1.20.0", extras=["broker"]}
+parver = '*'
+

--- a/examples/Pipfile.valid.with-categories
+++ b/examples/Pipfile.valid.with-categories
@@ -1,0 +1,5 @@
+[packages]
+plette = { path = '.', extras = ['validation'], editable = true }
+
+[documentaions]
+sphinx = "*"

--- a/src/plette/__main__.py
+++ b/src/plette/__main__.py
@@ -1,0 +1,24 @@
+"""
+A simple entry point which can be use to test Pipfiles
+
+e.g.
+
+python -m plette -f examples/Pipfile.valid.list 
+python -m plette -f examples/Pipfile.valid.editable
+# throws exception
+python -m plette -f examples/Pipfile.invalid.list  
+
+"""
+from plette import Pipfile
+
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument("-f", "--file", help="Input file")
+
+args = parser.parse_args()
+
+dest = args.file
+
+with open(dest) as f:
+    pipfile = Pipfile.load(f)

--- a/src/plette/models/__init__.py
+++ b/src/plette/models/__init__.py
@@ -16,5 +16,10 @@ from .scripts import Script
 from .sources import Source
 
 from .sections import (
-    Meta, Requires, PackageCollection, ScriptCollection, SourceCollection,
+    Meta,
+    Requires,
+    PackageCollection,
+    PipfileSection,
+    ScriptCollection,
+    SourceCollection,
 )

--- a/src/plette/models/packages.py
+++ b/src/plette/models/packages.py
@@ -21,7 +21,9 @@ class Package(DataView):
     def validate(cls, data):
         # HACK: Make this validatable for Cerberus. See comments in validation
         # side for more information.
-        return super(Package, cls).validate({"__package__": data})
+        super(Package, cls).validate({"__package__": data})
+        if isinstance(data, dict):
+            PackageSpecfiers.validate({"__specifiers__": data})
 
     def __getattr__(self, key):
         if isinstance(self._data, str):
@@ -41,3 +43,16 @@ class Package(DataView):
             self._data = value
         else:
             self._data[key] = value
+
+class PackageSpecfiers(DataView):
+    # TODO: one could add here more validation for path editable
+    # and more stuff which is currently allowed and undocumented
+    __SCHEMA__ = {
+        "__specifiers__": {
+            "type": "dict",
+            "schema":{
+                "version": {"type": "string"},
+                "extras": {"type": "list"},
+                }
+            }
+        }

--- a/src/plette/models/sections.py
+++ b/src/plette/models/sections.py
@@ -50,6 +50,16 @@ META_SECTIONS = {
     "sources": SourceCollection,
 }
 
+class PipfileSection(DataView):
+
+    """
+    Dummy pipfile validator that needs to be completed in a future PR
+    Hint: many pipfile features are undocumented in  pipenv/project.py
+    """
+
+    @classmethod
+    def validate(cls, data):
+        pass
 
 class Meta(DataView):
     """Representation of the `_meta` section in a Pipfile.lock."""

--- a/src/plette/pipfiles.py
+++ b/src/plette/pipfiles.py
@@ -4,7 +4,7 @@ import json
 import tomlkit
 
 from .models import (
-    DataView, Hash, Requires,
+    DataView, Hash, Requires, PipfileSection,
     PackageCollection, ScriptCollection, SourceCollection,
 )
 
@@ -15,6 +15,7 @@ PIPFILE_SECTIONS = {
     "dev-packages": PackageCollection,
     "requires": Requires,
     "scripts": ScriptCollection,
+    "pipfile":  PipfileSection
 }
 
 DEFAULT_SOURCE_TOML = """\

--- a/src/plette/pipfiles.py
+++ b/src/plette/pipfiles.py
@@ -24,7 +24,6 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 """
 
-
 class Pipfile(DataView):
     """Representation of a Pipfile.
     """
@@ -41,6 +40,11 @@ class Pipfile(DataView):
             if key not in data:
                 continue
             klass.validate(data[key])
+
+        package_categories = set(data.keys()) - set(PIPFILE_SECTIONS.keys())        
+
+        for category in package_categories:
+            PackageCollection.validate(data[category])
 
     @classmethod
     def load(cls, f, encoding=None):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -114,6 +114,18 @@ def test_package_wrong_key():
     assert str(ctx.value) == "version"
 
 
+@pytest.mark.skipif(cerberus is None, reason="Skip validation without Ceberus")
+def test_package_with_wrong_extras():
+    with pytest.raises(models.base.ValidationError):
+        p = models.Package({"version": "==1.20.0", "extras": "broker"})
+
+
+@pytest.mark.skipif(cerberus is None, reason="Skip validation without Ceberus")
+def test_package_with_extras():
+    p = models.Package({"version": "==1.20.0", "extras": ["broker", "tests"]})
+    assert p.extras == ['broker', 'tests']
+
+
 HASH = "9aaf3dbaf8c4df3accd4606eb2275d3b91c9db41be4fd5a97ecc95d79a12cfe6"
 
 


### PR DESCRIPTION
Until now one could write anything in package extras. If one happend to write a string, e.g:

```
msal = {version="==1.20.0", extras="broker"}
```

It would silently pass, and result in a Pipfile.lock containing a list of characters:

```
     "msal": {
            "extras": [
                "b",
                "e",
                "k",
                "o",
                "r"
            ],
```

With this change, a validation is added to check that extras are a list.
Also added is a check that packages specifiers are in a dictionary and not a list.

This is a potential fix for https://github.com/pypa/pipenv/issues/5440.