### PR TITLE
Remove python 2 warning

### DIFF
--- a/docs/files.rst
+++ b/docs/files.rst
@@ -16,12 +16,6 @@ This method takes a file-like object to load the file::
     >>> with open('Pipfile', encoding='utf-8') as f:
     ...     pipfile = plette.Pipfile.load(f)
 
-.. warning::
-
-    This will not work for Python 2, since the loader is very strict about
-    file encodings, and only accepts a Unicode file. You are required to use
-    ``io.open()`` to open the file instead.
-
 For manipulating a binary file (maybe because you want to interact with a
 temporary file created via ``tempfile.TemporaryFile()``), ``load()`` accepts
 a second, optional argument::


### PR DESCRIPTION
`plette` no longer supports `python 2`, so the warning is superfluous: https://github.com/sarugaku/plette/blob/cf27c30a645d31afaa72acae640a03e183e174da/pyproject.toml#L16-L24