### PR TITLE
migrate to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,11 @@
+[metadata]
+version = attr: plette.__version__
+
+[options]
+package_dir =
+     = src
+packages = find:
+include_package_data = True
+
+[options.packages.find]
+where = src

--- a/setup.py
+++ b/setup.py
@@ -1,33 +1,3 @@
-import ast
-import os
+from setuptools import setup
 
-from setuptools import find_packages, setup
-
-
-ROOT = os.path.dirname(__file__)
-
-PACKAGE_NAME = 'plette'
-
-VERSION = None
-
-with open(os.path.join(ROOT, 'src', PACKAGE_NAME, '__init__.py')) as f:
-    for line in f:
-        if line.startswith('__version__ = '):
-            VERSION = ast.literal_eval(line[len('__version__ = '):].strip())
-            break
-if VERSION is None:
-    raise EnvironmentError('failed to read version')
-
-
-setup(
-    # These really don't work.
-    package_dir={'': 'src'},
-    packages=find_packages('src'),
-
-    package_data={
-        '': ['LICENSE*', 'README*'],
-    },
-
-    # I need this to be dynamic.
-    version=VERSION,
-)
+setup()


### PR DESCRIPTION
I think I got it to work the way you wanted:
```
➜  python setup.py sdist                                                                                                                                                                                                      ✗ python setup.py sdist                                                                                                                                                                                                      k3d-mycluster
No `name` configuration, performing automatic discovery
Common parent package detected, name: plette
No `name` configuration, performing automatic discovery
Common parent package detected, name: plette
/Users/mathieu/.pyenv/versions/3.10.11/lib/python3.10/site-packages/setuptools/config/pyprojecttoml.py:66: _BetaConfiguration: Support for `[tool.setuptools]` in `pyproject.toml` is still *beta*.
  config = read_configuration(filepath, True, ignore_option_errors, dist)
running sdist
running egg_info
writing src/plette.egg-info/PKG-INFO
writing dependency_links to src/plette.egg-info/dependency_links.txt
writing requirements to src/plette.egg-info/requires.txt
writing top-level names to src/plette.egg-info/top_level.txt
reading manifest file 'src/plette.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
adding license file 'LICENSE'
writing manifest file 'src/plette.egg-info/SOURCES.txt'
running check
creating plette-0.4.4
creating plette-0.4.4/src
creating plette-0.4.4/src/plette
creating plette-0.4.4/src/plette.egg-info
creating plette-0.4.4/src/plette/models
creating plette-0.4.4/tests
copying files to plette-0.4.4...
copying LICENSE -> plette-0.4.4
copying MANIFEST.in -> plette-0.4.4
copying README.rst -> plette-0.4.4
copying pyproject.toml -> plette-0.4.4
copying setup.cfg -> plette-0.4.4
copying setup.py -> plette-0.4.4
copying src/plette/__init__.py -> plette-0.4.4/src/plette
copying src/plette/__main__.py -> plette-0.4.4/src/plette
copying src/plette/lockfiles.py -> plette-0.4.4/src/plette
copying src/plette/pipfiles.py -> plette-0.4.4/src/plette
copying src/plette.egg-info/PKG-INFO -> plette-0.4.4/src/plette.egg-info
copying src/plette.egg-info/SOURCES.txt -> plette-0.4.4/src/plette.egg-info
copying src/plette.egg-info/dependency_links.txt -> plette-0.4.4/src/plette.egg-info
copying src/plette.egg-info/requires.txt -> plette-0.4.4/src/plette.egg-info
copying src/plette.egg-info/top_level.txt -> plette-0.4.4/src/plette.egg-info
copying src/plette.egg-info/zip-safe -> plette-0.4.4/src/plette.egg-info
copying src/plette/models/__init__.py -> plette-0.4.4/src/plette/models
copying src/plette/models/base.py -> plette-0.4.4/src/plette/models
copying src/plette/models/hashes.py -> plette-0.4.4/src/plette/models
copying src/plette/models/packages.py -> plette-0.4.4/src/plette/models
copying src/plette/models/scripts.py -> plette-0.4.4/src/plette/models
copying src/plette/models/sections.py -> plette-0.4.4/src/plette/models
copying src/plette/models/sources.py -> plette-0.4.4/src/plette/models
copying tests/test_lockfiles.py -> plette-0.4.4/tests
copying tests/test_models.py -> plette-0.4.4/tests
copying tests/test_pipfiles.py -> plette-0.4.4/tests
copying tests/test_scripts.py -> plette-0.4.4/tests
Writing plette-0.4.4/setup.cfg
Creating tar archive
removing 'plette-0.4.4' (and everything under it)
```